### PR TITLE
Fix: Replace expired TikTok CDN thumbnail URLs with gradient fallbacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1276,7 +1276,11 @@
         <div class="video-grid">
             <!-- News Videos -->
             <div class="video-card" data-category="news" onclick="window.open('https://www.tiktok.com/@todoaqui_bol/video/7531529605409361157', '_blank')">
-                <div class="video-thumbnail" style="background-image: url('https://p16-sign-va.tiktokcdn.com/tos-maliva-p-0068/o48gAF8iqkEMQAk0A7AIIXwijfCLZnCEgBlBou~tplv-tiktokx-origin.image?dr=14575&x-expires=1754006400&x-signature=rFLIY86pR8T0yC9Ixqwgiw84%2BB0%3D&t=4d5b0474&ps=13740610&shp=b59d6b55&shcp=43f4a2f9&idc=maliva'); background-size: cover; background-position: center;">
+                <div class="video-thumbnail" style="background: linear-gradient(135deg, #FF0050, #00F2EA); background-size: cover; background-position: center;">
+                    <div class="video-thumbnail-content">
+                        <h3 class="emoji">🎉</h3>
+                        <p>TODO AQUÍ</p>
+                    </div>
                     <div class="play-button">
                         <div class="play-icon"></div>
                     </div>
@@ -1294,7 +1298,11 @@
             </div>
 
             <div class="video-card" data-category="sports" onclick="window.open('https://www.tiktok.com/@todoaqui_bol/video/7532528412863335736', '_blank')">
-                <div class="video-thumbnail" style="background-image: url('https://p16-sign-va.tiktokcdn.com/tos-maliva-p-0068/o8IBVigMAvZfC4RQr05MAgEIZAECIAPvBH6tio~tplv-tiktokx-dmt-logom:tos-useast2a-v-0068/okdiBIIYsiCQqrUoBuA6CjJIE4iBAV6AAaAvE.image?dr=14573&x-expires=1754006400&x-signature=CjbdmfMJbvsefAbU3PLacTMSTsA%3D&t=4d5b0474&ps=13740610&shp=b59d6b55&shcp=43f4a2f9&idc=maliva'); background-size: cover; background-position: center;">
+                <div class="video-thumbnail" style="background: linear-gradient(135deg, #2ecc71, #27ae60); background-size: cover; background-position: center;">
+                    <div class="video-thumbnail-content">
+                        <h3 class="emoji">⚽</h3>
+                        <p>Deportes</p>
+                    </div>
                     <div class="play-button">
                         <div class="play-icon"></div>
                     </div>
@@ -1313,7 +1321,11 @@
 
 
             <div class="video-card" data-category="news" onclick="window.open('https://www.tiktok.com/@todoaqui_bol/video/7532314746268175621', '_blank')">
-                <div class="video-thumbnail" style="background-image: url('https://p16-sign-va.tiktokcdn.com/tos-maliva-p-0068/ogeT6AJDoC5puLXFEAAODAE2EBoIfidQQRIMCH~tplv-tiktokx-dmt-logom:tos-useast2a-v-0068/oQfogXREETDijR8EfyFTHIAYB8A5QQC4OPAJ0A.image?dr=14573&x-expires=1754100000&x-signature=v9VbQpX4qR1Rg0NNqJcvQxGCmxk%3D&t=4d5b0474&ps=13740610&shp=b59d6b55&shcp=43f4a2f9&idc=maliva'); background-size: cover; background-position: center;">
+                <div class="video-thumbnail" style="background: linear-gradient(135deg, #e74c3c, #c0392b); background-size: cover; background-position: center;">
+                    <div class="video-thumbnail-content">
+                        <h3 class="emoji">📰</h3>
+                        <p>Noticias</p>
+                    </div>
                     <div class="play-button">
                         <div class="play-icon"></div>
                     </div>


### PR DESCRIPTION
- Replaced expired TikTok CDN URLs that had time-limited x-expires parameters
- Added colorful gradient backgrounds with category-specific emojis and labels
- Each video thumbnail now displays appropriate category icons (🎉, ⚽, 📰)
- Maintains existing functionality while ensuring thumbnails are always visible
- Uses brand colors consistent with site design

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)