### PR TITLE
Remove Rodrigo Barron and add Niklaus Geisser

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Todo Aquí Bolivia - Rodrigo Barron, Paola Sivila</title>
+    <title>Todo Aquí Bolivia - Niklaus Geisser, Paola Sivila</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' style='stop-color:%23FF0050'/%3E%3Cstop offset='100%25' style='stop-color:%2300F2EA'/%3E%3C/linearGradient%3E%3C/defs%3E%3Ccircle cx='50' cy='50' r='45' fill='url(%23g)'/%3E%3Ctext x='50' y='60' font-family='Arial Black' font-size='36' font-weight='900' text-anchor='middle' fill='white'%3ETA%3C/text%3E%3C/svg%3E">
     <style>
         * {
@@ -1187,7 +1187,7 @@
             <h1 class="logo">Todo Aquí</h1>
             <p class="tagline">Lo mejor de Bolivia: Noticias, Deportes y Gastronomía</p>
             <p style="font-size: 1rem; opacity: 0.8; margin-top: -0.5rem; margin-bottom: 2rem;">🇧🇴 Contenido 100% Boliviano</p>
-            <p style="font-size: 0.9rem; opacity: 0.7; margin-bottom: 2rem;">con Rodrigo Barron y Paola Sivila</p>
+            <p style="font-size: 0.9rem; opacity: 0.7; margin-bottom: 2rem;">con Niklaus Geisser y Paola Sivila</p>
             <a href="#categories" class="cta-button">
                 <span>Descubre Bolivia</span>
             </a>
@@ -1199,31 +1199,23 @@
         <h2 class="section-title">Nuestro Equipo</h2>
         <div class="team-grid">
             <div class="team-member">
-                <div class="member-avatar sports">
-                    <img src="https://i.imgur.com/ESIQxHO.jpeg" alt="Rodrigo Barron" />
+                <div class="member-avatar technology">
+                    <img src="https://via.placeholder.com/150x150/FF0050/FFFFFF?text=NG" alt="Niklaus Geisser" />
                 </div>
-                <h3 class="member-name">Rodrigo Barron</h3>
-                <p class="member-role">Deportes</p>
-                <p class="member-bio">Experto en deportes y fanático de La Verde. Rodrigo cubre la Liga Boliviana, Copa Libertadores y todo el deporte desde la altura.</p>
+                <h3 class="member-name">Niklaus Geisser</h3>
+                <p class="member-role">Tecnología y Deportes</p>
+                <p class="member-bio">Especialista en tecnología y deportes. Niklaus cubre innovación, gadgets, La Verde, Liga Boliviana y todo el deporte boliviano desde una perspectiva moderna.</p>
             </div>
             <div class="team-member">
                 <div class="member-avatar kitchen">
                     <img src="https://i.imgur.com/1QUfGoH.jpeg" alt="Paola Sivila" />
                 </div>
                 <h3 class="member-name">Paola Sivila</h3>
-                <p class="member-role">Gastronomía</p>
-                <p class="member-bio">Chef paceña especializada en cocina tradicional. Paola rescata las recetas de nuestras abuelas para las nuevas generaciones.</p>
+                <p class="member-role">Noticias y Gastronomía</p>
+                <p class="member-bio">Periodista y chef paceña. Paola cubre las últimas noticias de Bolivia y rescata las recetas tradicionales de nuestras abuelas para las nuevas generaciones.</p>
             </div>
         </div>
         
-        <!-- Team Photo Section -->
-        <div class="team-photo-section">
-            <h3 class="team-photo-title">Unidos por Bolivia</h3>
-            <p class="team-photo-subtitle">Dos especialistas bolivianos, múltiples pasiones, un solo objetivo: mostrar lo mejor de Bolivia al mundo</p>
-            <div class="team-photo-container">
-                <img src="https://i.imgur.com/qfifd2d.jpeg" alt="Todo Aquí - Equipo Completo" class="team-photo" />
-            </div>
-        </div>
     </section>
 
     <!-- Categories Section -->
@@ -1241,8 +1233,15 @@
                 <div class="category-bg" style="background: linear-gradient(135deg, #2ecc71, #27ae60); opacity: 0.1;"></div>
                 <span class="category-icon">⚽</span>
                 <h3 class="category-title">Deportes</h3>
-                <p class="category-host">con Rodrigo Barron</p>
+                <p class="category-host">con Niklaus Geisser</p>
                 <p class="category-description">La Verde, Liga Boliviana, Wilstermann, Bolívar, The Strongest y más. Todo el fútbol boliviano y deportes de altura en un solo lugar.</p>
+            </div>
+            <div class="category-card" data-category="technology">
+                <div class="category-bg" style="background: linear-gradient(135deg, #3498db, #2980b9); opacity: 0.1;"></div>
+                <span class="category-icon">💻</span>
+                <h3 class="category-title">Tecnología</h3>
+                <p class="category-host">con Niklaus Geisser</p>
+                <p class="category-description">Últimas tendencias tech, gadgets, apps y innovación. Todo lo que necesitas saber sobre tecnología desde Bolivia.</p>
             </div>
             <div class="category-card" data-category="kitchen">
                 <div class="category-bg" style="background: linear-gradient(135deg, #f39c12, #e67e22); opacity: 0.1;"></div>


### PR DESCRIPTION
Resolves #8

## Summary
- Replace Rodrigo Barron with Niklaus Geisser in team section
- Add new "Tecnología" sector for Niklaus
- Update Paola's role to handle both news and kitchen sectors
- Add placeholder image for Niklaus Geisser
- Remove group photo section as requested

## Test plan
- [ ] Review team section displays correctly
- [ ] Verify new Tecnología category appears
- [ ] Check Paola's updated responsibilities
- [ ] Confirm group photo section is removed

🤖 Generated with [Claude Code](https://claude.ai/code)